### PR TITLE
A couple of readme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ There's also a simple API which can be accessed from the move module:
   
   - Move adds a shorthand for calling functions without parens. E.g. `foo(bar)` is equivalent to `foo! bar` and `Some.foo(strip(bar))` can be written as `Some.foo! strip! bar`.
 
-- **Variables** need not be explicitly declared. Move will declare a newfound variable in the scope which it first was used. This behavior is deterministic, in contrast to the ambiguous way implicitly declared variables behave in JavaScript.
+- **Variables** need not be explicitly declared. Move will declare a newfound variable in the scope which it first was used. 
 
-- **No commas** required to terminate expressions. Move will determine when a comma is needed so you don't have to (and the code gets more readable).
+- **No semicolons** required to terminate expressions. Move will determine when a semicolon is needed so you don't have to (and the code gets more readable).
 
 - No type-coercing **equality operators** -- in Move, `==` does not perform type coercion and behaves just like `===` in JavaScript. Same goes for `!=`.
 


### PR DESCRIPTION
I think I found one place where you intended to say "semicolon" rather than "comma" and another place where it seemed too strong to call out javascript for being nondeterministic, as I believe the Move feature in response doesn't remove the nondeterminism.
